### PR TITLE
Add MANIFEST.in to include files required by pip/easy installation from package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include CHANGELOG


### PR DESCRIPTION
When installing from package/PyPI, "setup.py install" cannot find README.md or CHANGELOG which are required by setup.py, therefore the install fails.

Replicate with:

```
pip install pifacecommon
```
