### PR TITLE
spi_ioc_transfer structure with tx_nbits/rx_nbits and smaller pad

### DIFF
--- a/pifacecommon/linux_spi_spidev.py
+++ b/pifacecommon/linux_spi_spidev.py
@@ -67,7 +67,9 @@ class spi_ioc_transfer(ctypes.Structure):
         ("delay_usecs", ctypes.c_uint16),
         ("bits_per_word", ctypes.c_uint8),
         ("cs_change", ctypes.c_uint8),
-        ("pad", ctypes.c_uint32)]
+        ("tx_nbits", ctypes.c_uint8),
+        ("rx_nbits", ctypes.c_uint8),
+        ("pad", ctypes.c_uint16)]
 
     __slots__ = [name for name, type in _fields_]
 


### PR DESCRIPTION
The current linux/spi/spidev.h and drivers/spi/spidev.c implementation contains already since Feb 25, 2014 with commit torvalds/linux/commit/dc64d39 a change, that tx_nbits & rx_nbits where introduced and pad is not longer uint32 but uint16 now.
For pifacecommon it's not a big issue, the PR will reflect the current structure only, because initializing one uint32 only or (uint16 + uint8 + uint8) ist the same at the end with 32