### PR TITLE
reflect preferred installation and changelog update

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+v4.2.2
+------
+-  Set explicit SPI frequency to allow board to work in newer kernels which has too high default frequency (PR#23)
+
 v4.2.0
 ------
 - Added daemon flag for PortEventListener.

--- a/README.md
+++ b/README.md
@@ -21,9 +21,16 @@ Make sure you are using the lastest version of Raspbian:
     $ sudo apt-get update
     $ sudo apt-get upgrade
 
-Install `pifacecommon` (for Python 3 and 2) with the following command:
+Install `pifacecommon` with the following commands:
 
-    $ sudo apt-get install python{,3}-pifacecommon
+    Python 2:
+    $ sudo pip pifacecommon
+
+    Python 3:
+    $ sudo pip3 pifacecommon
+
+    Notice: Installation from Raspbian repository with apt is not longer the preferred way, take a look into [https://github.com/piface/pifacecommon/issues/27#issuecomment-451400154](issue 27)
+    
 
 You will also need to set up automatic loading of the SPI kernel module which
 can be done with the lastest version of `raspi-config`. Run:

--- a/README.md
+++ b/README.md
@@ -23,13 +23,12 @@ Make sure you are using the lastest version of Raspbian:
 
 Install `pifacecommon` with the following commands:
 
-    Python 2:
-    $ sudo pip pifacecommon
-
     Python 3:
-    $ sudo pip3 pifacecommon
+    $ sudo pip3 install pifacecommon
 
-    Notice: Installation from Raspbian repository with apt is not longer the preferred way, take a look into [https://github.com/piface/pifacecommon/issues/27#issuecomment-451400154](issue 27)
+    Notice 1: Installation from Raspbian repository with apt is not longer the preferred way, take a look into [https://github.com/piface/pifacecommon/issues/27#issuecomment-451400154](issue 27)
+    
+    Notice 2: Python 2 support is "end-of-life" since Jan 2020, refer to https://www.python.org/doc/sunset-python-2/
     
 
 You will also need to set up automatic loading of the SPI kernel module which


### PR DESCRIPTION
In #27 you proposed the usage of pip installation instead of aptitute package manager
and changelog should be up-to-date, too